### PR TITLE
+fix: HTTP context options

### DIFF
--- a/src/ripcord/ripcord_client.php
+++ b/src/ripcord/ripcord_client.php
@@ -470,7 +470,7 @@ class  Ripcord_Transport_Stream implements Ripcord_Transport
 	 */
 	public function post( $url, $request ) 
 	{
-		$options = array_merge( 
+		$options = array_merge_recursive( 
 			$this->options, 
 			array( 
 				'http' => array(


### PR DESCRIPTION
Accepting options for http connection (http://php.net/manual/en/context.http.php)

If the http call is behind a proxy or the server is down it will hanging for a while, to set a timeout we need to be able to change the HTTP context options. Right now there is no way to modify the `$this->options['http']`, even if we try to set the timeout in Ripcord_Transport_Stream it will be replaced. With this change we can do something like this:
`
$transport = new \Ripcord_Transport_Stream([
            'http' => [
                'timeout' => 20
            ]
        ]);
        return ripcord::client($endPoint, null, $transport);
`