### PR TITLE
Add a note. Fixes #8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,8 +77,9 @@ $this->odoo = $this->odoo
             ->username('my-user-name')
             ->password('my-password)
             ->db('my-db')
-            ->host('my-host.com')
+            ->host('https://my-host.com')
             ->connect();
+// Note: `host` should contain 'http://' or 'https://'
 ```
 
 


### PR DESCRIPTION
Added a note to one of the usage examples. Which will help the user to avoid `Undefined variable: http_response_header` error ( Fixes #8 ).