### PR TITLE
Better error handling

### DIFF
--- a/src/Odoo.php
+++ b/src/Odoo.php
@@ -695,19 +695,21 @@ class Odoo
 
     /**
      * Prepare the api response.
-     * If there is a faultCode then return its value.
+     * If there is a faultCode throw an exception.
      * If key passed, returns the value of that key.
      * Otherwise return the provided data.
      *
      * @param Collection $result
      * @param string $key
      * @param null $cast Cast returned data based on this param.
+     * @throws OdooException
      * @return mixed
      */
     private function makeResponse($result, $key = null, $cast = null)
     {
-        if (array_key_exists('faultCode', $result->toArray()))
-            return $result['faultCode'];
+        if (array_key_exists('faultCode', $result->toArray())) {
+            throw new OdooException($result['faultString']);
+        }
 
         if (!is_null($key) && array_key_exists($key, $result->toArray()))
             $result = $result->get($key);

--- a/src/ripcord/ripcord_client.php
+++ b/src/ripcord/ripcord_client.php
@@ -482,12 +482,14 @@ class  Ripcord_Transport_Stream implements Ripcord_Transport
 		);
 		$context = stream_context_create( $options );
 		$result  = @file_get_contents( $url, false, $context );
-		$this->responseHeaders = $http_response_header;
+
 		if ( !$result )
 		{
 			throw new Ripcord_TransportException( 'Could not access ' . $url, 
 				ripcord::cannotAccessURL );
 		}
+
+		$this->responseHeaders = $http_response_header;
 		return $result;
 	}
 }


### PR DESCRIPTION
This PR addresses two issues regarding error handling.

First, if request to Odoo fails with `faultCode`, current behavior is to simply return the fault code. This can be somewhat dangerous as there is no real indicator that an error even occurred. If user relies on API call to return an id of the record, he/she can mistakenly use the faultCode, without even knowing it happened. Instead, an exception should be thrown, preferably with `faultString` as message, to completely halt the process.

Second, if there is no connection to remote URL, the `$http_response_header` is never set, which leads to undefined variable error.